### PR TITLE
Throw an error if no address in payments file

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -282,7 +282,11 @@ switch (process.title) {
 
         details = JSON.parse(data)
         config.recipients = {}
-        details.forEach((entry) => { config.recipients[entry.address] = entry.probi || entry.satoshis })
+        details.forEach((entry) => {
+          if (!entry.address) throw new Error('undefined address for ' + JSON.stringify(entry))
+
+          config.recipients[entry.address] = entry.probi || entry.satoshis
+        })
 
         file = program.unsignedTx || outFile(program.payments, 'payments-', 'unsigned-')
         fs.access(file, fs.F_OK, (err) => {


### PR DESCRIPTION
online-create-transaction --wallet wallet-settlement-wallet-001.json
--payments ~/Desktop/publishers-20180103-160617-456.json
/Users/mrose/Documents/Projects/brave.com/brave-payments-tools/cli.js:286
if (!entry.address) throw new Error('undefined address for ' + JSON.stringify(entry))
^

Error: undefined address for {"publisher":"chrisruppel.com","altcurrency":"BAT","probi":"10842929709045949482","fees":"570680511002418393","authority":"github:mrose17","transactionId":"64e5d92f-3f7c-4f7a-84c1-476e260f48ca","currency":"LTC"}
at details.forEach (/Users/mrose/Documents/Projects/brave.com/brave-payments-tools/cli.js:286:37)
at Array.forEach (<anonymous>)
at fs.readFile (/Users/mrose/Documents/Projects/brave.com/brave-payments-tools/cli.js:285:17)
at FSReqWrap.readFileAfterClose [as oncomplete] (fs.js:511:3)
  