### PR TITLE
updates based on experience!

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,21 +129,19 @@ e.g.,
 
     which contains a list of publisher settlements
 
-2. An unsigned transaction is created,
-and then transferred to the cold machine.
+2. The payments file is transferred to the cold machine.
 
 3. On the cold machine,
-the transaction is signed (requiring the operator to enter the passphrase for the keypair's private key).
+an unsigned transaction is created,
+and then the transaction is signed (requiring the operator to enter the passphrase for the keypair's private key).
 
 4. The signed transaction is then transferred to the networked machine and submitted to the BitGo server.
 
-## On the Networked Machine
+## On the Cold Machine
 
-    % bin/online-create-transaction \
+    % bin/offline-create-transaction \
         --wallet wallet-779826ce-a74f-4d61-907a-0d238db9808f.json \
         --payments payments-batch1.json 
-    prompt: OTP: ...
-    prompt: Application access-token: ...
 
     wrote unsigned-batch1.json
 
@@ -169,8 +167,6 @@ e.g.,
       ],
       "authenticate": {}
     }
-
-## On the Cold Machine
 
     % bin/offline-sign-transaction \
         --unsignedTx unsigned-batch1.json

--- a/bin/offline-create-transaction
+++ b/bin/offline-create-transaction
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+
+var fs = require('fs')
+var path = require('path')
+require(path.join(path.dirname(fs.realpathSync(__filename)), '../cli'))

--- a/lib/uphold-online.js
+++ b/lib/uphold-online.js
@@ -61,7 +61,11 @@ module.exports = {
    , wallet       : { id             : '...'
                     , currency       : 'BAT
                     }
-   , recipients   : { 'address'      : probi }
+   , recipients   : [ { address      : '...'
+                      , probi        : '...'
+                      }
+                      ...
+                    ]
    , message      : '...'
    }
  */
@@ -69,18 +73,18 @@ module.exports = {
     (options, callback) => {
       const result = { config: options.config, unsignedTxs: [] }
 
-      underscore.keys(options.recipients).forEach((destination) => {
+      for (let destination of options.recipients) {
         result.unsignedTxs.push({
           denomination: {
-            amount: new BigNumber(options.recipients[destination]).dividedBy('1e18').toString(),
+            amount: new BigNumber(destination.probi).dividedBy('1e18').toString(),
             currency: options.wallet.currency
           },
-          destination: destination,
+          destination: destination.address,
           message: options.message,
           id: options.wallet.id,
           label: options.label
         })
-      })
+      }
       callback(null, result, options)
     },
 
@@ -110,7 +114,10 @@ module.exports = {
           submit = underscore.extend(underscore.pick(result, [ 'status', 'message' ]),
                                      { hash: result.id, walletId: result.origin.CardId, tx: options.signedTx.octets },
                                      underscore.pick(result.destination, [ 'currency', 'amount', 'commission', 'fee' ]))
-          callback(null, submit, options)
+          setTimeout(() => {
+            console.log('zzz')
+            callback(null, submit, options)
+          }, 1000)
         }).catch((err) => {
           callback(err, null, options)
         })

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "bin": {
     "offline-create-keychains": "./bin/offline-create-keychains",
     "offline-recover-passphrases": "./bin/offline-recover-passphrases",
+    "offline-create-transaction": "./bin/offline-create-transaction",
     "offline-sign-transaction": "./bin/offline-sign-transaction",
     "offline-show-key": "./bin/offline-show-key",
     "offline-split-passphrases": "./bin/offline-split-passphrases",

--- a/scripts/uphold/getCards.js
+++ b/scripts/uphold/getCards.js
@@ -24,7 +24,7 @@ const generate = (startPage) => {
 
       setTimeout(() => { fetch(pageno + 1) }, 5 * 1000)
     }).catch((err) => {
-      console.log(json2csv({ data: data }))
+      console.log(JSON.stringify(err, null, 2))
       throw err
     })
   }

--- a/scripts/uphold/transferBAT.js
+++ b/scripts/uphold/transferBAT.js
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+
+/* jshint asi: true, node: true, laxbreak: true, laxcomma: true, undef: true, unused: true, esversion: 6 */
+
+const BigNumber = require('bignumber.js')
+const braveCrypto = require('brave-crypto')
+const crypto = require('crypto')
+const LedgerClient = require('bat-client')
+const sign = require('http-request-signature').sign
+const stringify = require('json-stable-stringify')
+const underscore = require('underscore')
+const UpholdSDK = require('@uphold/uphold-sdk-javascript')
+
+let headers
+let uphold
+
+const transfer = (source, keypair, destination, amount) => {
+  const body = { denomination: { amount: amount, currency: 'BAT' }, destination: destination }
+
+  transact(source, keypair, body, false, (result) => {
+    console.log('before: ' + body.denomination.amount)
+    body.denomination.amount = new BigNumber(body.denomination.amount)
+    if (body.denomination.amount.isZero()) return console.log('zero balance')
+    body.denomination.amount = body.denomination.amount.minus(new BigNumber(result.origin.fee))
+    if (body.denomination.amount.lessThanOrEqualTo(0)) return console.log('insufficient balance: ' + amount)
+    body.denomination.amount = body.denomination.amount.toString()
+    console.log(' after: ' + body.denomination.amount)
+    transact(source, keypair, body, true, () => {})
+  })
+}
+
+const transact = (source, keypair, body, commitP, callback) => {
+  const octets = stringify(body)
+  const signature = {
+    digest: 'SHA-256=' + crypto.createHash('sha256').update(octets).digest('base64'),
+    signature: sign({ headers: headers, keyId: 'primary', secretKey: braveCrypto.uint8ToHex(keypair.secretKey) },
+                    { algorithm: 'ed25519' })
+  }
+  const signedTx = {
+    id: source,
+    requestType: 'httpSignature',
+    signedTx: { headers: underscore.extend(signature, headers), body: body, octets: octets }
+  }
+
+  uphold.createCardTransaction(source,
+                               underscore.extend(underscore.pick(body, [ 'destination' ]), body.denomination),
+                               commitP,
+                               null,
+      { headers: signedTx.signedTx.headers, body: signedTx.signedTx.octets }).then((result) => {
+        console.log('status=' + result.status)
+        callback(result)
+      })
+}
+
+switch (process.argv.length) {
+  case 7:
+    uphold = new UpholdSDK.default({ // eslint-disable-line new-cap
+      baseUrl: 'https://api.uphold.com',
+      clientId: '0000000000000000000000000000000000000000',
+      clientSecret: '0000000000000000000000000000000000000000'
+    })
+
+    headers = {
+      authorization: 'Basic ' + Buffer.from(process.argv[2] + ':X-OAuth-Basic').toString('base64')
+    }
+
+    return transfer(process.argv[3], LedgerClient(null, { roundtrip: () => {} }, null).recoverKeypair(process.argv[4]),
+                    process.argv[5], process.argv[6])
+
+  default:
+    console.log('usage: ' + process.argv[0] + ' ' + process.argv[1] + ' <accessToken> <source> <seed> <destination> <BAT>')
+    process.exit(1)
+}


### PR DESCRIPTION
- add offline-create-transaction for uphold
- do not require the access token for *-create-transaction for uphold
- handle both payments-* and referrals-* prefixes
- when creating an unsigned file, do not collapse the file based on destination address for uphold
- for uphold, during de-mux of transactions for submissions, handle errors “less gracefully”